### PR TITLE
Fix powerup duration during pause

### DIFF
--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -409,15 +409,18 @@ export class GameManager {
       );
     }
 
-    // Start music if we should be playing and aren't already
-    if (shouldPlayMusic && !this.isBackgroundMusicPlaying) {
-      log.audio("Starting background music");
-      this.audioManager.playSound(AudioEvent.BACKGROUND_MUSIC, currentState);
-      this.isBackgroundMusicPlaying = true;
-    }
-
-    // Stop music if we shouldn't be playing but are
-    if (!shouldPlayMusic && this.isBackgroundMusicPlaying) {
+    // Always check if we need to start music when in PLAYING state
+    // This ensures music restarts after powerup melody or after loading a new map
+    if (shouldPlayMusic) {
+      // Check if music is actually playing in the AudioManager
+      // If not, start it (even if we think it's playing)
+      if (!this.audioManager.isBackgroundMusicActuallyPlaying()) {
+        log.audio("Starting/Restarting background music");
+        this.audioManager.playSound(AudioEvent.BACKGROUND_MUSIC, currentState);
+        this.isBackgroundMusicPlaying = true;
+      }
+    } else if (this.isBackgroundMusicPlaying) {
+      // Stop music if we shouldn't be playing but are
       log.audio("Stopping background music");
       this.audioManager.stopBackgroundMusic();
       this.isBackgroundMusicPlaying = false;

--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -412,17 +412,19 @@ export class GameManager {
     // Always check if we need to start music when in PLAYING state
     // This ensures music restarts after powerup melody or after loading a new map
     if (shouldPlayMusic) {
-      // Check if music is actually playing in the AudioManager
-      // If not, start it (even if we think it's playing)
+      // Always check actual audio state, not our local flag
+      // This handles cases where powerup melody stopped the music
       if (!this.audioManager.isBackgroundMusicActuallyPlaying()) {
         log.audio("Starting/Restarting background music");
         this.audioManager.playSound(AudioEvent.BACKGROUND_MUSIC, currentState);
-        this.isBackgroundMusicPlaying = true;
       }
-    } else if (this.isBackgroundMusicPlaying) {
-      // Stop music if we shouldn't be playing but are
-      log.audio("Stopping background music");
-      this.audioManager.stopBackgroundMusic();
+      this.isBackgroundMusicPlaying = true;
+    } else {
+      // Stop music if we shouldn't be playing
+      if (this.isBackgroundMusicPlaying || this.audioManager.isBackgroundMusicActuallyPlaying()) {
+        log.audio("Stopping background music");
+        this.audioManager.stopBackgroundMusic();
+      }
       this.isBackgroundMusicPlaying = false;
     }
 

--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -415,17 +415,17 @@ export class GameManager {
       // Always check actual audio state, not our local flag
       // This handles cases where powerup melody stopped the music
       if (!this.audioManager.isBackgroundMusicActuallyPlaying()) {
-        log.audio("Starting/Restarting background music");
+        log.audio(`Starting/Restarting background music (local flag: ${this.isBackgroundMusicPlaying})`);
         this.audioManager.playSound(AudioEvent.BACKGROUND_MUSIC, currentState);
+        this.isBackgroundMusicPlaying = true;
       }
-      this.isBackgroundMusicPlaying = true;
     } else {
       // Stop music if we shouldn't be playing
       if (this.isBackgroundMusicPlaying || this.audioManager.isBackgroundMusicActuallyPlaying()) {
-        log.audio("Stopping background music");
+        log.audio(`Stopping background music (local flag: ${this.isBackgroundMusicPlaying})`);
         this.audioManager.stopBackgroundMusic();
+        this.isBackgroundMusicPlaying = false;
       }
-      this.isBackgroundMusicPlaying = false;
     }
 
     this.previousGameState = currentState;

--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -370,6 +370,12 @@ export class GameManager {
       this.scalingManager.resumeAllMonsterScaling();
       this.monsterSpawnManager.resume();
       this.monsterRespawnManager.resume();
+      
+      // Resume coin manager to restore powerup durations
+      const gameState = useGameStore.getState();
+      if (gameState.coinManager) {
+        gameState.coinManager.resume();
+      }
     } else {
       // Stop power-up melody when game is paused/stopped
       if (this.audioManager.isPowerUpMelodyActive()) {
@@ -381,6 +387,12 @@ export class GameManager {
       this.scalingManager.pauseAllMonsterScaling();
       this.monsterSpawnManager.pause();
       this.monsterRespawnManager.pause();
+      
+      // Pause coin manager to preserve powerup durations
+      const gameState = useGameStore.getState();
+      if (gameState.coinManager) {
+        gameState.coinManager.pause();
+      }
     }
   }
 


### PR DESCRIPTION
Pause and resume powerup effect durations to prevent them from expiring during game pause.

---
<a href="https://cursor.com/background-agent?bcId=bc-63796df2-036a-404f-a56c-84c5bddfe8d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63796df2-036a-404f-a56c-84c5bddfe8d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

