### PR TITLE
Fix background music not starting after powerup

### DIFF
--- a/src/managers/coinManager.ts
+++ b/src/managers/coinManager.ts
@@ -14,6 +14,7 @@ import { CoinPhysics } from "./coinPhysics";
 import { COIN_TYPES, P_COIN_COLORS, COIN_EFFECTS } from "../config/coinTypes";
 import { log } from "../lib/logger";
 import { ScalingManager } from "./ScalingManager";
+import { useGameStore } from "../stores/gameStore";
 
 interface EffectData {
   endTime: number;
@@ -788,6 +789,13 @@ export class CoinManager {
       this.powerModeActive = false;
       this.powerModeEndTime = 0;
       this.activeEffects.delete("POWER_MODE");
+      
+      // Stop the powerup melody when force stopping power mode
+      const gameState = useGameStore.getState();
+      if (gameState.audioManager && typeof gameState.audioManager.stopPowerUpMelody === 'function') {
+        log.debug("Force stopping PowerUp melody");
+        gameState.audioManager.stopPowerUpMelody();
+      }
       
       // Resume difficulty scaling
       try {


### PR DESCRIPTION
Fix background music not starting on the next map when completing a level with an active powerup.

The background music failed to resume on the next map because `resumeBackgroundMusic()` only adjusted volume if music was already playing, rather than restarting it when stopped. This, combined with powerup melody cessation during map clear, left the background music in a permanently stopped state. The fix ensures `resumeBackgroundMusic()` properly restarts music and adds state checks to prevent audio conflicts during game state transitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-4360d06a-c181-441a-b1b1-9469ae86e140">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4360d06a-c181-441a-b1b1-9469ae86e140">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

