### PR TITLE
Adjust background music and audio states

### DIFF
--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -42,17 +42,22 @@ export class GameManager {
   private playerManager: PlayerManager;
 
   constructor(canvas: HTMLCanvasElement) {
-    // Initialize supporting managers
-    this.collisionManager = new CollisionManager();
-    this.renderManager = new RenderManager(canvas);
-    this.audioManager = new AudioManager();
+    // Create managers
     this.animationController = new AnimationController(playerSprite);
+    this.renderManager = new RenderManager(canvas);
+    this.collisionManager = new CollisionManager();
+    this.audioManager = new AudioManager();
+    this.inputManager = new InputManager();
+    this.levelManager = new LevelManager();
     this.scalingManager = ScalingManager.getInstance();
     this.monsterRespawnManager = OptimizedRespawnManager.getInstance();
     this.playerManager = new PlayerManager(this.animationController);
     this.monsterSpawnManager = new OptimizedSpawnManager();
 
-    // Initialize specialized managers
+    // Set up player death callback
+    this.playerManager.setDeathCallback(() => this.handlePlayerDeath());
+
+    // Create higher-level managers that depend on the above
     this.gameStateManager = new GameStateManager(
       this.audioManager,
       this.scalingManager,
@@ -253,7 +258,11 @@ export class GameManager {
   private handlePlayerDeath(): void {
     const gameState = useGameStore.getState();
     
+    // Stop any power-up effects
     this.powerUpManager.handlePlayerDeath();
+    
+    // Stop background music immediately when player dies
+    this.audioManager.stopBackgroundMusic();
     this.gameStateManager.resetBackgroundMusicFlag();
 
     if (gameState.lives <= 1) {

--- a/src/managers/GameStateManager.ts
+++ b/src/managers/GameStateManager.ts
@@ -146,7 +146,13 @@ export class GameStateManager {
   }
 
   public handleBackgroundMusic(currentState: GameState): void {
-    const shouldPlayMusic = currentState === GameState.PLAYING;
+    // Check if we should play music:
+    // 1. State must be PLAYING
+    // 2. PowerUp melody must NOT be active
+    const shouldPlayMusic = 
+      currentState === GameState.PLAYING && 
+      !this.audioManager.isPowerUpMelodyActive();
+    
     const stateChanged = this.previousGameState !== currentState;
 
     if (stateChanged) {
@@ -163,8 +169,9 @@ export class GameStateManager {
     }
 
     // Stop music if we shouldn't be playing but are
+    // This includes: non-PLAYING states OR PowerUp melody is active
     if (!shouldPlayMusic && this.isBackgroundMusicPlaying) {
-      log.audio("Stopping background music");
+      log.audio(`Stopping background music (state: ${currentState}, powerUp: ${this.audioManager.isPowerUpMelodyActive()})`);
       this.audioManager.stopBackgroundMusic();
       this.isBackgroundMusicPlaying = false;
     }

--- a/src/managers/PlayerManager.ts
+++ b/src/managers/PlayerManager.ts
@@ -9,6 +9,7 @@ export class PlayerManager {
   private collisionManager: CollisionManager;
   private animationController: AnimationController;
   private bounds: { width: number; height: number };
+  private onPlayerDeath?: () => void;
 
   constructor(animationController: AnimationController) {
     this.collisionManager = new CollisionManager();
@@ -17,6 +18,10 @@ export class PlayerManager {
       width: GAME_CONFIG.CANVAS_WIDTH,
       height: GAME_CONFIG.CANVAS_HEIGHT,
     };
+  }
+
+  public setDeathCallback(callback: () => void): void {
+    this.onPlayerDeath = callback;
   }
 
   update(deltaTime: number): void {
@@ -53,8 +58,13 @@ export class PlayerManager {
     );
 
     if (boundaryResult.fellOffScreen) {
-      // Player fell off screen
-      gameState.loseLife();
+      // Player fell off screen - use death callback if available
+      if (this.onPlayerDeath) {
+        this.onPlayerDeath();
+      } else {
+        // Fallback to direct loseLife if no callback set
+        gameState.loseLife();
+      }
       return;
     }
 


### PR DESCRIPTION
Refactor game state and player death handling to ensure background music plays only during the `PLAYING` state (when no power-up melody is active) and stops correctly during all other states and upon player death.

---
<a href="https://cursor.com/background-agent?bcId=bc-78556176-dec9-4a69-99f3-c9a282581058">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78556176-dec9-4a69-99f3-c9a282581058">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

