### PR TITLE
Fix background music and game reset bugs

### DIFF
--- a/src/components/menu/menus/GameOverScreen.tsx
+++ b/src/components/menu/menus/GameOverScreen.tsx
@@ -1,12 +1,23 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { useGameStore } from "../../../stores/gameStore";
+import { GameState, MenuType } from "../../../types/enums";
 
 const GameOverScreen: React.FC = () => {
-  const { score, resetGame, levelHistory } = useGameStore();
+  const { score, resetGame, levelHistory, setState, setMenuType } = useGameStore();
 
   const handleRestart = () => {
+    // Reset the game (this now also loads the first level)
     resetGame();
+    
+    // Show countdown before starting
+    setMenuType(MenuType.COUNTDOWN);
+    setState(GameState.COUNTDOWN);
+    
+    // After 3 seconds, start the game
+    setTimeout(() => {
+      setState(GameState.PLAYING);
+    }, 3000);
   };
 
   return (

--- a/src/components/menu/menus/PauseMenu.tsx
+++ b/src/components/menu/menus/PauseMenu.tsx
@@ -23,19 +23,21 @@ const PauseMenu: React.FC = () => {
   };
 
   const quitToMenu = () => {
+    // Reset the game (this now also loads the first level)
     resetGame();
+    // Set to menu state with start menu
     setState(GameState.MENU);
     setMenuType(MenuType.START);
   };
 
   const restartGame = () => {
-    // Reset everything back to level 1
+    // Reset everything back to level 1 (this now also loads the first level)
     const { resetGame } = useGameStore.getState();
     resetGame();
 
-    // Set state to MENU to trigger level reload in GameManager
-    setState(GameState.MENU);
+    // Show countdown before starting
     setMenuType(MenuType.COUNTDOWN);
+    setState(GameState.COUNTDOWN);
 
     // After 3 seconds, start the game
     setTimeout(() => {

--- a/src/components/menu/menus/VictoryMenu.tsx
+++ b/src/components/menu/menus/VictoryMenu.tsx
@@ -1,14 +1,20 @@
 import React from "react";
 
 import { useGameStore } from "../../../stores/gameStore";
+import { GameState, MenuType } from "../../../types/enums";
 
 import { Home, RotateCcw, Trophy } from "lucide-react";
 
 const VictoryMenu: React.FC = () => {
-  const { score, resetGame } = useGameStore();
+  const { score, resetGame, setState, setMenuType } = useGameStore();
 
   const handleRestart = () => {
+    // Reset the game (this now also loads the first level)
     resetGame();
+    
+    // Return to the start menu
+    setState(GameState.MENU);
+    setMenuType(MenuType.START);
   };
 
   return (

--- a/src/managers/AudioManager.ts
+++ b/src/managers/AudioManager.ts
@@ -12,7 +12,7 @@ interface WebkitWindow extends Window {
 export class AudioManager {
   private audioContext: AudioContext | null = null;
   private backgroundMusicGain: GainNode | null = null;
-  private isBackgroundMusicPlaying = false;
+  private _isBackgroundMusicPlaying = false;
   private backgroundMusicBuffer: AudioBuffer | null = null;
   private backgroundMusicSource: AudioBufferSourceNode | null = null;
 
@@ -97,7 +97,7 @@ export class AudioManager {
   }
 
   stopBackgroundMusic(): void {
-    this.isBackgroundMusicPlaying = false;
+    this._isBackgroundMusicPlaying = false;
 
     // Stop the current audio source if playing
     if (this.backgroundMusicSource) {
@@ -108,6 +108,11 @@ export class AudioManager {
       }
       this.backgroundMusicSource = null;
     }
+  }
+
+  // Public getter for background music playing status
+  public get isBackgroundMusicPlaying(): boolean {
+    return this._isBackgroundMusicPlaying;
   }
 
   private playBombCollectSound(): void {
@@ -306,12 +311,12 @@ export class AudioManager {
   private startBackgroundMusic(): void {
     if (
       !this.audioContext ||
-      this.isBackgroundMusicPlaying ||
+      this._isBackgroundMusicPlaying ||
       !this.backgroundMusicBuffer
     )
       return;
 
-    this.isBackgroundMusicPlaying = true;
+    this._isBackgroundMusicPlaying = true;
     this.playBackgroundMusicFile();
   }
 
@@ -320,7 +325,7 @@ export class AudioManager {
       !this.audioContext ||
       !this.backgroundMusicGain ||
       !this.backgroundMusicBuffer ||
-      !this.isBackgroundMusicPlaying
+      !this._isBackgroundMusicPlaying
     )
       return;
 
@@ -334,10 +339,10 @@ export class AudioManager {
 
       // Handle when the audio ends (for non-looping or if loop is disabled)
       this.backgroundMusicSource.onended = () => {
-        if (this.isBackgroundMusicPlaying) {
+        if (this._isBackgroundMusicPlaying) {
           // Restart the music if it should still be playing
           setTimeout(() => {
-            if (this.isBackgroundMusicPlaying) {
+            if (this._isBackgroundMusicPlaying) {
               this.playBackgroundMusicFile();
             }
           }, 100);
@@ -469,7 +474,7 @@ export class AudioManager {
   public resumeBackgroundMusic(): void {
     if (this.backgroundMusicGain) {
       // If background music should be playing but source is gone, restart it
-      if (this.isBackgroundMusicPlaying && !this.backgroundMusicSource) {
+      if (this._isBackgroundMusicPlaying && !this.backgroundMusicSource) {
         log.audio("Background music source lost, restarting music");
         this.playBackgroundMusicFile();
       }
@@ -478,7 +483,7 @@ export class AudioManager {
       this.updateAudioVolumes();
       
       // Log the resume attempt for debugging
-      log.audio(`resumeBackgroundMusic: isPlaying=${this.isBackgroundMusicPlaying}, hasSource=${this.backgroundMusicSource !== null}, gainValue=${this.backgroundMusicGain.gain.value}`);
+      log.audio(`resumeBackgroundMusic: isPlaying=${this._isBackgroundMusicPlaying}, hasSource=${this.backgroundMusicSource !== null}, gainValue=${this.backgroundMusicGain.gain.value}`);
     }
   }
 
@@ -522,7 +527,7 @@ export class AudioManager {
     // Music is only actually playing if we have a source and the flag is set
     // and power-up melody is not active (which would mute the background music)
     return (
-      this.isBackgroundMusicPlaying &&
+      this._isBackgroundMusicPlaying &&
       this.backgroundMusicSource !== null &&
       !this.powerUpMelodyActive
     );
@@ -534,7 +539,7 @@ export class AudioManager {
       isActive: this.powerUpMelodyActive,
       hasTimeout: this.powerUpMelodyTimeout !== null,
       timeoutId: this.powerUpMelodyTimeout,
-      backgroundMusicPlaying: this.isBackgroundMusicPlaying,
+      backgroundMusicPlaying: this._isBackgroundMusicPlaying,
     };
   }
 }

--- a/src/managers/GameStateManager.ts
+++ b/src/managers/GameStateManager.ts
@@ -180,6 +180,16 @@ export class GameStateManager {
       this.isBackgroundMusicPlaying = false;
     }
 
+    // Explicitly handle PAUSED state to ensure music stops
+    if (currentState === GameState.PAUSED) {
+      // Force stop background music when paused
+      if (this.audioManager.isBackgroundMusicPlaying) {
+        log.audio("Game paused, forcing background music stop");
+        this.audioManager.stopBackgroundMusic();
+        this.isBackgroundMusicPlaying = false;
+      }
+    }
+
     this.previousGameState = currentState;
   }
 

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -23,6 +23,7 @@ import {
 import { InputSlice, createInputSlice } from "./slices/inputSlice";
 import { MapDefinition } from "../types/interfaces";
 import { CoinManager } from "../managers/coinManager";
+import { mapDefinitions } from "../maps/mapDefinitions";
 
 interface GameStore
   extends PlayerSlice,
@@ -71,6 +72,7 @@ export const useGameStore = create<GameStore>((set, get, api) => {
     ...inputSlice,
 
     resetGame: () => {
+      // Reset all state slices
       get().resetGameState();
       get().resetPlayer();
       get().resetBombState();
@@ -82,6 +84,13 @@ export const useGameStore = create<GameStore>((set, get, api) => {
       get().resetEffects();
       get().clearAllFloatingTexts();
       get().resetInput();
+      
+      // After resetting everything, load the first level
+      // This ensures the game is in a playable state with the first map loaded
+      const firstMap = mapDefinitions[0];
+      if (firstMap) {
+        get().initializeLevel(firstMap);
+      }
     },
 
     // Override initializeLevel to handle the full game initialization

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,9 +5,9 @@ export const VERSION = {
   major: 2,
   minor: 5,
   patch: 0,
-  build: 3,
-  timestamp: 1755903423754,
-  hash: 'L1P2VL',
+  build: 4,
+  timestamp: 1755906557816,
+  hash: 'HP8NKS',
   full: '2.5.0'
 };
 


### PR DESCRIPTION
Fixes background music not stopping when the game is paused and ensures `resetGame` properly reloads the first level.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e891402-c12c-4240-9a1a-c9b55f622812">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e891402-c12c-4240-9a1a-c9b55f622812">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

