### PR TITLE
Centralize game state and fix pause race conditions

### DIFF
--- a/src/components/menu/menus/AudioSettingsMenu.tsx
+++ b/src/components/menu/menus/AudioSettingsMenu.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { useGameStore } from "../../../stores/gameStore";
-import { MenuType } from "../../../types/enums";
+
 import { ArrowLeft } from "lucide-react";
 
 const AudioSettingsMenu: React.FC = () => {
-  const { setMenuType, previousMenu } = useGameStore();
+  const { gameStateManager } = useGameStore();
   
   // Get audio settings from AudioManager
   const audioSettings = useGameStore((state) => state.audioSettings);
@@ -30,13 +30,8 @@ const AudioSettingsMenu: React.FC = () => {
   };
 
   const goBack = () => {
-    // Go back to the previous menu that was stored when opening settings
-    if (previousMenu) {
-      setMenuType(previousMenu);
-    } else {
-      // Fallback to START menu if no previous menu is stored
-      setMenuType(MenuType.START);
-    }
+    // Use centralized close settings transition
+    gameStateManager?.closeSettings();
   };
 
   return (

--- a/src/components/menu/menus/GameOverScreen.tsx
+++ b/src/components/menu/menus/GameOverScreen.tsx
@@ -1,23 +1,14 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { useGameStore } from "../../../stores/gameStore";
-import { GameState, MenuType } from "../../../types/enums";
+
 
 const GameOverScreen: React.FC = () => {
-  const { score, resetGame, levelHistory, setState, setMenuType } = useGameStore();
+  const { score, levelHistory, gameStateManager } = useGameStore();
 
   const handleRestart = () => {
-    // Reset the game (this now also loads the first level)
-    resetGame();
-    
-    // Show countdown before starting
-    setMenuType(MenuType.COUNTDOWN);
-    setState(GameState.COUNTDOWN);
-    
-    // After 3 seconds, start the game
-    setTimeout(() => {
-      setState(GameState.PLAYING);
-    }, 3000);
+    // Use centralized restart transition
+    gameStateManager?.restartGame();
   };
 
   return (

--- a/src/components/menu/menus/InGameMenu.tsx
+++ b/src/components/menu/menus/InGameMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { useGameStore } from "../../../stores/gameStore";
-import { GameState, MenuType } from "../../../types/enums";
+
 import {
   Play,
   Pause,
@@ -26,8 +26,7 @@ const InGameMenu: React.FC = () => {
     score,
     lives,
     currentLevel,
-    setState,
-    setMenuType,
+    gameStateManager,
     isPaused,
     multiplier,
     multiplierScore,
@@ -36,12 +35,8 @@ const InGameMenu: React.FC = () => {
   const { isFullscreen, toggleFullscreen } = useFullscreen();
 
   const togglePause = () => {
-    if (isPaused) {
-      setState(GameState.PLAYING);
-    } else {
-      setState(GameState.PAUSED);
-      setMenuType(MenuType.PAUSE);
-    }
+    // Use centralized pause/resume transition
+    gameStateManager?.togglePause();
   };
 
   const handleFullscreenToggle = () => {

--- a/src/components/menu/menus/PauseMenu.tsx
+++ b/src/components/menu/menus/PauseMenu.tsx
@@ -1,48 +1,30 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { useGameStore } from "../../../stores/gameStore";
-import { GameState, MenuType } from "../../../types/enums";
+
 import { Play, Settings, Home, RotateCcw } from "lucide-react";
 
 const PauseMenu: React.FC = () => {
-  const { setState, setMenuType, resetGame } = useGameStore();
+  const { gameStateManager } = useGameStore();
 
   const resumeGame = () => {
-    // Show countdown before resuming
-    setMenuType(MenuType.COUNTDOWN);
-    setState(GameState.COUNTDOWN);
-
-    // After 3 seconds, start the game
-    setTimeout(() => {
-      setState(GameState.PLAYING);
-    }, 3000);
+    // Use centralized resume transition
+    gameStateManager?.resumeGame();
   };
 
   const openSettings = () => {
-    setMenuType(MenuType.SETTINGS);
+    // Use centralized settings transition
+    gameStateManager?.openSettings();
   };
 
   const quitToMenu = () => {
-    // Reset the game (this now also loads the first level)
-    resetGame();
-    // Set to menu state with start menu
-    setState(GameState.MENU);
-    setMenuType(MenuType.START);
+    // Use centralized quit to menu transition
+    gameStateManager?.quitToMenu();
   };
 
   const restartGame = () => {
-    // Reset everything back to level 1 (this now also loads the first level)
-    const { resetGame } = useGameStore.getState();
-    resetGame();
-
-    // Show countdown before starting
-    setMenuType(MenuType.COUNTDOWN);
-    setState(GameState.COUNTDOWN);
-
-    // After 3 seconds, start the game
-    setTimeout(() => {
-      setState(GameState.PLAYING);
-    }, 3000);
+    // Use centralized restart transition
+    gameStateManager?.restartGame();
   };
 
   return (

--- a/src/components/menu/menus/SettingsMenu.tsx
+++ b/src/components/menu/menus/SettingsMenu.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { useGameStore } from "../../../stores/gameStore";
-import { MenuType } from "../../../types/enums";
+
 import { ArrowLeft } from "lucide-react";
 
 const SettingsMenu: React.FC = () => {
-  const { setMenuType, previousMenu } = useGameStore();
+  const { gameStateManager } = useGameStore();
 
   // Get audio settings from AudioManager
   const audioSettings = useGameStore((state) => state.audioSettings);
@@ -30,13 +30,8 @@ const SettingsMenu: React.FC = () => {
   };
 
   const goBack = () => {
-    // Go back to the previous menu that was stored when opening settings
-    if (previousMenu) {
-      setMenuType(previousMenu);
-    } else {
-      // Fallback to START menu if no previous menu is stored
-      setMenuType(MenuType.START);
-    }
+    // Use centralized close settings transition
+    gameStateManager?.closeSettings();
   };
 
   return (

--- a/src/components/menu/menus/StartMenu.tsx
+++ b/src/components/menu/menus/StartMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { useGameStore } from "../../../stores/gameStore";
-import { GameState, MenuType } from "../../../types/enums";
+
 import { Maximize, Minimize, Play, Settings } from "lucide-react";
 import {
   Tooltip,
@@ -12,24 +12,18 @@ import {
 import { useFullscreen } from "../../../hooks/useFullscreen";
 
 const StartMenu: React.FC = () => {
-  const { setState, setMenuType } = useGameStore();
+  const { gameStateManager } = useGameStore();
   const { isFullscreen, toggleFullscreen } = useFullscreen();
   const gameContainerRef = useRef<HTMLDivElement>(null);
 
   const startGame = () => {
-    // First hide the start menu
-    setMenuType(MenuType.COUNTDOWN);
-    // Then set countdown state
-    setState(GameState.COUNTDOWN);
-
-    // After 3 seconds, start the game
-    setTimeout(() => {
-      setState(GameState.PLAYING);
-    }, 3000);
+    // Use centralized state transition
+    gameStateManager?.startNewGame();
   };
 
   const openSettings = () => {
-    setMenuType(MenuType.SETTINGS);
+    // Use centralized settings transition
+    gameStateManager?.openSettings();
   };
 
   const handleFullscreenToggle = () => {

--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -108,6 +108,11 @@ export class GameManager {
     if ("setAudioManager" in gameState) {
       gameState.setAudioManager(this.audioManager);
     }
+    
+    // Set GameStateManager reference in store
+    if ("setGameStateManager" in gameState) {
+      gameState.setGameStateManager(this.gameStateManager);
+    }
   }
 
   /**

--- a/src/stores/slices/gameStateSlice.ts
+++ b/src/stores/slices/gameStateSlice.ts
@@ -36,6 +36,7 @@ export interface GameStateSlice {
   previousMenu: MenuType | null;
   isPaused: boolean;
   bonusAnimationComplete: boolean;
+  gameStateManager?: any; // Reference to GameStateManager instance
 
   setState: (state: GameState) => void;
   setMenuType: (menuType: MenuType) => void;
@@ -46,6 +47,7 @@ export interface GameStateSlice {
   addScore: (points: number) => void;
   resetLevelScores: () => void;
   resetGameState: () => void;
+  setGameStateManager: (manager: any) => void;
 }
 
 export const createGameStateSlice: StateCreator<GameStateSlice> = (
@@ -261,6 +263,10 @@ export const createGameStateSlice: StateCreator<GameStateSlice> = (
         isPaused: false,
         bonusAnimationComplete: false,
       });
+    },
+
+    setGameStateManager: (manager: any) => {
+      set({ gameStateManager: manager });
     },
   };
 };

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,9 +5,9 @@ export const VERSION = {
   major: 2,
   minor: 5,
   patch: 0,
-  build: 4,
-  timestamp: 1755906557816,
-  hash: 'HP8NKS',
+  build: 5,
+  timestamp: 1755946434596,
+  hash: 'YADOZE',
   full: '2.5.0'
 };
 


### PR DESCRIPTION
Centralize game state transitions and pause/resume logic in `GameStateManager` to eliminate race conditions and improve consistency.

The previous implementation had state transition logic scattered across various menu components, leading to potential inconsistencies and race conditions, especially with game pausing. This refactor ensures a single source of truth for all game state changes and establishes a correct order for pausing and resuming game managers.

---
<a href="https://cursor.com/background-agent?bcId=bc-e08116bc-25dd-43e3-b279-dc157b040d0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e08116bc-25dd-43e3-b279-dc157b040d0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

