### PR TITLE
Centralize game pause state logic

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useGameStore } from "../stores/gameStore";
-import { GameState, MenuType } from "../types/enums";
+import { GameState } from "../types/enums";
 
 // Type definition for webkit fullscreen element
 interface WebkitDocument extends Document {
@@ -8,7 +8,7 @@ interface WebkitDocument extends Document {
 }
 
 export const useKeyboardShortcuts = (onFullscreenToggle?: () => void) => {
-  const { currentState, setState, setMenuType, isPaused, updateAudioSettings, audioSettings } = useGameStore();
+  const { currentState, gameStateManager, audioSettings, updateAudioSettings } = useGameStore();
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -40,21 +40,17 @@ export const useKeyboardShortcuts = (onFullscreenToggle?: () => void) => {
 
         case "p":
         case "P":
-          // Pause/unpause game if playing, or resume if paused
+          // Use centralized pause/resume logic through GameStateManager
           if (currentState === GameState.PLAYING) {
             event.preventDefault();
-            setState(GameState.PAUSED);
-            setMenuType(MenuType.PAUSE);
-          } else if (isPaused) {
+            // Use the GameStateManager to pause the game
+            // This ensures all managers are properly paused
+            gameStateManager?.pauseGame();
+          } else if (currentState === GameState.PAUSED) {
             event.preventDefault();
-            // Use the same resume logic as the pause menu button
-            setMenuType(MenuType.COUNTDOWN);
-            setState(GameState.COUNTDOWN);
-            
-            // After 3 seconds, start the game
-            setTimeout(() => {
-              setState(GameState.PLAYING);
-            }, 3000);
+            // Use the GameStateManager to resume the game
+            // This ensures all managers are properly resumed
+            gameStateManager?.resumeGame();
           }
           break;
 
@@ -72,5 +68,5 @@ export const useKeyboardShortcuts = (onFullscreenToggle?: () => void) => {
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [currentState, isPaused, setState, setMenuType, onFullscreenToggle, updateAudioSettings, audioSettings.masterMuted]);
+  }, [currentState, gameStateManager, onFullscreenToggle, updateAudioSettings, audioSettings.masterMuted]);
 };


### PR DESCRIPTION
Centralize game pause/resume logic to fix race conditions where game systems continued running while paused.

Previously, the pause state was set from multiple locations, leading to inconsistencies. This PR ensures all pause/resume actions are routed through `GameStateManager`, which now synchronously pauses/resumes all relevant game managers (e.g., `CoinManager`, `ScalingManager`, `SpawnManager`) and background music immediately upon state change, preventing systems from progressing during a pause.

---
<a href="https://cursor.com/background-agent?bcId=bc-98c55df8-be72-4107-91b5-1df5c1833005">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98c55df8-be72-4107-91b5-1df5c1833005">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

