### PR TITLE
Fix bonus animation state transition

### DIFF
--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -300,15 +300,17 @@ export class GameManager {
     // Check for bonus animation completion and auto-continue
     if (
       gameState.currentState === GameState.BONUS &&
-      gameState.bonusAnimationComplete &&
-      !DEV_CONFIG.ENABLED
+      gameState.bonusAnimationComplete
     ) {
+      log.debug("Bonus animation complete, scheduling transition to next level");
+      // Reset the flag immediately to prevent multiple calls
+      gameState.setBonusAnimationComplete(false);
+      
       // Animation is complete, proceed to next level after a brief delay
       setTimeout(() => {
+        log.debug("Executing transition to next level after bonus screen");
         this.proceedToNextLevel();
       }, 2000); // 2 second delay after animation completes
-      // Reset the flag to prevent multiple calls
-      gameState.setBonusAnimationComplete(false);
     }
 
     if (gameState.currentState === GameState.PLAYING) {
@@ -1022,6 +1024,8 @@ export class GameManager {
   private proceedToNextLevel(): void {
     const gameState = useGameStore.getState();
     const nextLevel = gameState.currentLevel + 1;
+    
+    log.info(`Proceeding to next level: ${gameState.currentLevel} -> ${nextLevel}`);
 
     // Stop power-up melody if active (level transition)
     if (this.audioManager.isPowerUpMelodyActive()) {

--- a/src/stores/slices/gameStateSlice.ts
+++ b/src/stores/slices/gameStateSlice.ts
@@ -97,6 +97,7 @@ export const createGameStateSlice: StateCreator<GameStateSlice> = (
     },
 
     setBonusAnimationComplete: (complete: boolean) => {
+      log.debug(`Bonus animation completed, setting flag for transition: ${complete}`);
       set({ bonusAnimationComplete: complete });
     },
 


### PR DESCRIPTION
Fix bonus screen auto-continue by correcting flag reset timing and removing DEV mode restriction.

The `bonusAnimationComplete` flag was reset after the `setTimeout` was created, which could lead to multiple timeouts being scheduled on successive frames. This PR moves the flag reset to immediately after detection, preventing duplicate transitions. Additionally, the auto-continue was previously disabled in development mode, which has been removed to ensure consistent behavior across environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0e2527d-1a5b-4e52-94c9-156d40b2e8ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0e2527d-1a5b-4e52-94c9-156d40b2e8ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

