### PR TITLE
Fix bonus screen state update

### DIFF
--- a/src/managers/GameLoopManager.ts
+++ b/src/managers/GameLoopManager.ts
@@ -90,6 +90,11 @@ export class GameLoopManager {
       this.updatePlaying(deltaTime);
     } else if (gameState.currentState === GameState.MAP_CLEARED) {
       this.updateMapCleared(deltaTime);
+    } else if (gameState.currentState === GameState.BONUS) {
+      // Call the update callback during BONUS state to allow checking for bonus animation completion
+      if (this.onUpdate) {
+        this.onUpdate(deltaTime);
+      }
     }
 
     this.render();


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable `GameLoopManager` updates during the `BONUS` state to allow proper game progression after the bonus screen.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the `GameLoopManager` only called update callbacks during `PLAYING` and `MAP_CLEARED` states. This prevented `GameStateManager.handleBonusCompletion()` from being executed during the `BONUS` state, causing the game to freeze after the bonus animation completed.

---
<a href="https://cursor.com/background-agent?bcId=bc-93c054ed-981e-4d0d-826a-50d8e8c0070c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93c054ed-981e-4d0d-826a-50d8e8c0070c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

