### PR TITLE
Fix game start menu and state transition bugs

### DIFF
--- a/src/components/MainGame.tsx
+++ b/src/components/MainGame.tsx
@@ -20,7 +20,8 @@ import { useBackgroundPreloading } from "../hooks/useBackgroundPreloading";
 import { VERSION_STRING, getVersion } from "../version";
 
 const MainGame: React.FC = () => {
-  const { currentState, showMenu } = useStateStore.getState();
+  // Fix: Use the store hooks properly to subscribe to state changes
+  const { currentState, showMenu } = useStateStore();
   const gameContainerRef = React.useRef<HTMLDivElement>(null);
   const { toggleFullscreen } = useFullscreen();
   const { isFullscreen } = useFullscreen();

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ShortcutControls from "../ShortcutControls";
-import { useGameStore } from "../../stores/gameStore";
+import { useGameStore, useStateStore } from "../../stores/gameStore";
 import { GameState } from "@/types/enums";
 
 const Menu = ({
@@ -10,7 +10,7 @@ const Menu = ({
   children: React.ReactNode;
   transparent?: boolean;
 }) => {
-  const { currentState } = useGameStore();
+  const { currentState } = useStateStore();
 
   return (
     <div

--- a/src/components/menu/menus/BonusScreen.tsx
+++ b/src/components/menu/menus/BonusScreen.tsx
@@ -15,10 +15,11 @@ import { log } from "../../../lib/logger";
 import { useAnimatedCounter } from "../../../hooks/useAnimatedCounter";
 
 const BonusScreen: React.FC = () => {
-  const { currentLevel, correctOrderCount, lives } = useStateStore.getState();
-  const { currentMap } = useLevelStore.getState();
+  const { currentLevel, correctOrderCount, lives } = useStateStore();
+  const { score } = useScoreStore();
+  const { setBonusAnimationComplete, gameStateManager } = useStateStore();
+  const { currentMap } = useLevelStore();
 
-  const { setBonusAnimationComplete } = useStateStore.getState();
   const livesLost = GAME_CONFIG.STARTING_LIVES - lives;
   const effectiveCount = Math.max(0, correctOrderCount - livesLost);
 

--- a/src/components/menu/menus/CountdownOverlay.tsx
+++ b/src/components/menu/menus/CountdownOverlay.tsx
@@ -4,7 +4,7 @@ import { useLevelStore } from "../../../stores/gameStore";
 
 const CountdownOverlay: React.FC = () => {
   const [count, setCount] = useState(3);
-  const { currentMap } = useLevelStore.getState();
+  const { currentMap } = useLevelStore();
   useEffect(() => {
     // Only run countdown if not in DEV_MODE
     if (!DEV_CONFIG.ENABLED) {

--- a/src/components/menu/menus/InGameMenu.tsx
+++ b/src/components/menu/menus/InGameMenu.tsx
@@ -28,10 +28,8 @@ import { TooltipProvider } from "@radix-ui/react-tooltip";
 
 const InGameMenu: React.FC = () => {
   const { currentLevel, gameStateManager, isPaused, lives } =
-    useStateStore.getState();
-  const { score } = useScoreStore.getState();
-  const { multiplier } = useScoreStore.getState();
-  const { multiplierScore } = useScoreStore.getState();
+    useStateStore();
+  const { score, multiplier, multiplierScore } = useScoreStore();
 
   const gameContainerRef = useRef<HTMLDivElement>(null);
   const { isFullscreen, toggleFullscreen } = useFullscreen();

--- a/src/managers/GameStateManager.ts
+++ b/src/managers/GameStateManager.ts
@@ -16,7 +16,7 @@ import type { OptimizedSpawnManager } from "./OptimizedSpawnManager";
 import type { OptimizedRespawnManager } from "./OptimizedRespawnManager";
 
 export class GameStateManager {
-  private previousGameState: GameState | null = null;
+  private previousGameState: GameState = GameState.MENU; // Initialize with MENU instead of null
   private isBackgroundMusicPlaying = false;
   private devModeInitialized = false;
   private bonusTransitionInProgress = false;

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,9 +5,9 @@ export const VERSION = {
   major: 2,
   minor: 5,
   patch: 0,
-  build: 5,
-  timestamp: 1755946434596,
-  hash: 'YADOZE',
+  build: 7,
+  timestamp: 1756018556775,
+  hash: 'BNJZIA',
   full: '2.5.0'
 };
 


### PR DESCRIPTION
Fix state transition bugs by ensuring components subscribe to state changes and initializing `GameStateManager` correctly.

Components were using `getState()` which provides a static snapshot, preventing re-renders when the game state changed. This has been updated to use the store hooks directly. Additionally, `GameStateManager`'s `previousGameState` was initialized to `null`, which is now set to `GameState.MENU` for proper state tracking.

---
<a href="https://cursor.com/background-agent?bcId=bc-cffa4df6-2a89-4359-9ff1-c52f6e7297a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cffa4df6-2a89-4359-9ff1-c52f6e7297a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

