### PR TITLE
Reset game state between maps

### DIFF
--- a/src/lib/AnimationController.ts
+++ b/src/lib/AnimationController.ts
@@ -53,6 +53,10 @@ export class AnimationController {
       if (isGrounded) {
         this.mapClearedFallComplete = true;
       }
+    } else if (gameState !== "MAP_CLEARED" && this.isMapCleared) {
+      // Reset MAP_CLEARED state when transitioning to a different state
+      this.isMapCleared = false;
+      this.mapClearedFallComplete = false;
     }
 
     // Check if landing animation finished

--- a/src/managers/LevelManager.ts
+++ b/src/managers/LevelManager.ts
@@ -243,13 +243,21 @@ export class LevelManager {
 
       // Increment level only once
       nextLevel();
-      this.loadCurrentLevel();
-
+      
       // Reset background music flag
       gameStateManager.resetBackgroundMusicFlag();
 
-      // Show countdown for next level
-      gameStateManager.showCountdown();
+      // IMPORTANT: Set state to COUNTDOWN BEFORE loading the new level
+      // This ensures MAP_CLEARED state doesn't persist to the new level
+      gameStateManager.setState(GameState.COUNTDOWN, MenuType.COUNTDOWN);
+      
+      // Now load the new level with a clean state
+      this.loadCurrentLevel();
+
+      // Start the countdown timer to transition to PLAYING
+      setTimeout(() => {
+        gameStateManager.setState(GameState.PLAYING);
+      }, 3000);
     } else {
       // All levels completed - victory!
       gameStateManager.setState(GameState.VICTORY, MenuType.VICTORY);

--- a/src/managers/LevelManager.ts
+++ b/src/managers/LevelManager.ts
@@ -64,6 +64,9 @@ export class LevelManager {
     if (currentLevel <= mapDefinitions.length) {
       const mapDefinition = mapDefinitions[currentLevel - 1];
       
+      // Reset map cleared state for new level
+      this.wasGroundedWhenMapCleared = false;
+      
       // Use the gameStore initializeLevel which properly sets up bombs, monsters, coins, and player
       gameStore.initializeLevel(mapDefinition);
 

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -79,6 +79,9 @@ export const useGameStore = create<GameStore>((set, get, api) => ({
     const monsterStore = useMonsterStore.getState();
     const playerStore = usePlayerStore.getState();
     
+    // IMPORTANT: Reset bomb state first to clear collectedBombs from previous level
+    stateStore.resetBombState();
+    
     // Initialize level
     const { bombManager, firstBomb } = levelStore.initializeLevel(mapData);
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,9 +5,9 @@ export const VERSION = {
   major: 2,
   minor: 5,
   patch: 0,
-  build: 10,
-  timestamp: 1756021291828,
-  hash: '3IBCMD',
+  build: 11,
+  timestamp: 1756021660145,
+  hash: 'DV9BEK',
   full: '2.5.0'
 };
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,9 +5,9 @@ export const VERSION = {
   major: 2,
   minor: 5,
   patch: 0,
-  build: 8,
-  timestamp: 1756018798664,
-  hash: 'JIUHQD',
+  build: 9,
+  timestamp: 1756020784298,
+  hash: 'K78WHC',
   full: '2.5.0'
 };
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,9 +5,9 @@ export const VERSION = {
   major: 2,
   minor: 5,
   patch: 0,
-  build: 9,
-  timestamp: 1756020784298,
-  hash: 'K78WHC',
+  build: 10,
+  timestamp: 1756021291828,
+  hash: '3IBCMD',
   full: '2.5.0'
 };
 


### PR DESCRIPTION
Reset `MAP_CLEARED` state flags to prevent persistence across new maps.

Previously, the `MAP_CLEARED` state (including flags like `isMapCleared` and `wasGroundedWhenMapCleared`) was not being reset when transitioning to a new map. This led to incorrect game behavior where elements of the previous map's cleared state would affect the new map. This PR ensures these flags are properly cleared during level initialization and state transitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-003bf7fb-eb92-4ee7-b801-7153444f34db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-003bf7fb-eb92-4ee7-b801-7153444f34db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

