### PR TITLE
Fix power up melody not playing

### DIFF
--- a/src/config/coinTypes.ts
+++ b/src/config/coinTypes.ts
@@ -11,6 +11,7 @@ import { CoinType } from "../types/enums";
 import { GAME_CONFIG } from "../types/constants";
 import { ScalingManager } from "../managers/ScalingManager";
 import { useScoreStore } from "../stores/gameStore";
+import { useAudioStore } from "../stores/systems/audioStore";
 
 // Define coin effects
 export const COIN_EFFECTS = {
@@ -68,22 +69,26 @@ export const COIN_EFFECTS = {
       }
 
       // Start power-up melody with the correct duration
-      if (gameState.audioManager && typeof gameState.audioManager.startPowerUpMelodyWithDuration === 'function') {
+      // Get audioManager from the audioStore instead of gameState
+      const audioStore = useAudioStore.getState();
+      if (audioStore.audioManager && typeof audioStore.audioManager.startPowerUpMelodyWithDuration === 'function') {
         console.log(`Starting PowerUp melody from coin effect for ${duration}ms`);
-        console.log(`AudioManager available:`, gameState.audioManager);
-        gameState.audioManager.startPowerUpMelodyWithDuration(duration);
+        console.log(`AudioManager available:`, audioStore.audioManager);
+        audioStore.audioManager.startPowerUpMelodyWithDuration(duration);
       } else {
         console.warn("AudioManager not available for PowerUp melody");
-        console.log(`GameState audioManager:`, gameState.audioManager);
-        console.log(`GameState keys:`, Object.keys(gameState));
+        console.log(`AudioStore audioManager:`, audioStore.audioManager);
+        console.log(`AudioStore keys:`, Object.keys(audioStore));
       }
     },
     remove: (gameState: GameStateInterface) => {
       console.log("Removing POWER_MODE effect, stopping PowerUp melody");
       
       // Stop power-up melody when effect ends
-      if (gameState.audioManager && typeof gameState.audioManager.stopPowerUpMelody === 'function') {
-        gameState.audioManager.stopPowerUpMelody();
+      // Get audioManager from the audioStore instead of gameState
+      const audioStore = useAudioStore.getState();
+      if (audioStore.audioManager && typeof audioStore.audioManager.stopPowerUpMelody === 'function') {
+        audioStore.audioManager.stopPowerUpMelody();
       } else {
         console.warn("AudioManager not available to stop PowerUp melody");
       }

--- a/src/managers/coinManager.ts
+++ b/src/managers/coinManager.ts
@@ -901,17 +901,17 @@ export class CoinManager {
 
         // Restart power-up melody if it's the POWER_MODE effect
         if (effectType === "POWER_MODE" && effectData.remainingDuration > 0) {
-          // Get the game state to access audioManager
-          const gameState = useAudioStore.getState();
+          // Get the audioManager from audioStore
+          const audioStore = useAudioStore.getState();
           if (
-            gameState?.audioManager &&
-            typeof gameState.audioManager.startPowerUpMelodyWithDuration ===
+            audioStore?.audioManager &&
+            typeof audioStore.audioManager.startPowerUpMelodyWithDuration ===
               "function"
           ) {
             log.debug(
               `Restarting PowerUp melody with ${effectData.remainingDuration}ms remaining`
             );
-            gameState.audioManager.startPowerUpMelodyWithDuration(
+            audioStore.audioManager.startPowerUpMelodyWithDuration(
               effectData.remainingDuration
             );
           }


### PR DESCRIPTION
Fix PowerUp melody not playing by retrieving AudioManager from `audioStore` instead of `gameState`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cf33c88-f0e1-4562-91aa-939fb1610e77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cf33c88-f0e1-4562-91aa-939fb1610e77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

