### PR TITLE
Fix background image reset in restartgame

### DIFF
--- a/src/components/menu/menus/GameOverScreen.tsx
+++ b/src/components/menu/menus/GameOverScreen.tsx
@@ -1,12 +1,29 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { useGameStore } from "../../../stores/gameStore";
+import { GameState, MenuType } from "../../../types/enums";
 
 const GameOverScreen: React.FC = () => {
-  const { score, resetGame, levelHistory } = useGameStore();
+  const { score, resetGame, levelHistory, setState, setMenuType } = useGameStore();
 
   const handleRestart = () => {
+    // Reset the game
     resetGame();
+    
+    // Ensure we're in MENU state first to trigger level reload
+    setState(GameState.MENU);
+    setMenuType(MenuType.START);
+
+    // Small delay to ensure the game loop processes the MENU state and loads the level
+    setTimeout(() => {
+      setMenuType(MenuType.COUNTDOWN);
+      setState(GameState.COUNTDOWN);
+      
+      // After countdown, start the game
+      setTimeout(() => {
+        setState(GameState.PLAYING);
+      }, 3000);
+    }, 100); // 100ms delay to ensure level loads
   };
 
   return (

--- a/src/components/menu/menus/PauseMenu.tsx
+++ b/src/components/menu/menus/PauseMenu.tsx
@@ -33,14 +33,20 @@ const PauseMenu: React.FC = () => {
     const { resetGame } = useGameStore.getState();
     resetGame();
 
-    // Set state to MENU to trigger level reload in GameManager
+    // Ensure we're in MENU state first to trigger level reload
     setState(GameState.MENU);
-    setMenuType(MenuType.COUNTDOWN);
+    setMenuType(MenuType.START);
 
-    // After 3 seconds, start the game
+    // Small delay to ensure the game loop processes the MENU state and loads the level
     setTimeout(() => {
-      setState(GameState.PLAYING);
-    }, 3000);
+      setMenuType(MenuType.COUNTDOWN);
+      setState(GameState.COUNTDOWN);
+      
+      // After countdown, start the game
+      setTimeout(() => {
+        setState(GameState.PLAYING);
+      }, 3000);
+    }, 100); // 100ms delay to ensure level loads
   };
 
   return (


### PR DESCRIPTION
Fix background image not reloading when restarting the game from GameOverScreen or PauseMenu.

The previous restart flow transitioned states too quickly, preventing the game loop from detecting the `MENU` state with a null `currentMap` and triggering the necessary level (and background) reload. This fix introduces a proper state sequence (`MENU` -> `COUNTDOWN` -> `PLAYING`) with a small delay after `MENU` to ensure the background loads correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-57d40c43-0b6f-401f-8f44-68e9e4cd7cd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57d40c43-0b6f-401f-8f44-68e9e4cd7cd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

