### PR TITLE
Fix background image reset in restartGame

### DIFF
--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -20,6 +20,7 @@ import {
   useMonsterStore,
   useCoinStore,
   useStateStore,
+  useRenderStore,
 } from "../stores/gameStore";
 import { GameState, AudioEvent } from "../types/enums";
 import { DEV_CONFIG, GAME_CONFIG } from "../types/constants";
@@ -113,6 +114,8 @@ export class GameManager {
     // Set AudioManager reference in store
     const { setAudioManager } = useAudioStore.getState();
     const { setGameStateManager } = useStateStore.getState();
+    const { setRenderManager } = useRenderStore.getState();
+    
     if (setAudioManager) {
       setAudioManager(this.audioManager);
     }
@@ -120,6 +123,11 @@ export class GameManager {
     // Set GameStateManager reference in store
     if (setGameStateManager) {
       setGameStateManager(this.gameStateManager);
+    }
+    
+    // Set RenderManager reference in store
+    if (setRenderManager) {
+      setRenderManager(this.renderManager);
     }
   }
 

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -70,6 +70,11 @@ export const useGameStore = create<GameStore>((set, get, api) => ({
     const firstMap = mapDefinitions[0];
     if (firstMap) {
       get().initializeLevel(firstMap);
+      
+      // Load the background for the first map if renderManager is available
+      if (renderStore.renderManager) {
+        renderStore.renderManager.loadMapBackground(firstMap.name);
+      }
     }
   },
 

--- a/src/stores/systems/renderStore.ts
+++ b/src/stores/systems/renderStore.ts
@@ -3,6 +3,7 @@ import { FloatingText } from '../../types/interfaces';
 
 interface RenderState {
   floatingTexts: FloatingText[];
+  renderManager?: any; // Reference to RenderManager instance
 }
 
 interface RenderActions {
@@ -10,6 +11,7 @@ interface RenderActions {
   removeFloatingText: (id: string) => void;
   updateFloatingTexts: () => void;
   clearAllFloatingTexts: () => void;
+  setRenderManager: (manager: any) => void;
 }
 
 export type RenderStore = RenderState & RenderActions;
@@ -17,6 +19,7 @@ export type RenderStore = RenderState & RenderActions;
 export const useRenderStore = create<RenderStore>((set, get) => ({
   // State
   floatingTexts: [],
+  renderManager: undefined,
   
   // Actions
   addFloatingText: (text: string, x: number, y: number, duration: number = 1000, color: string = '#FFFFFF', fontSize: number = 16) => {
@@ -54,5 +57,9 @@ export const useRenderStore = create<RenderStore>((set, get) => ({
   
   clearAllFloatingTexts: () => {
     set({ floatingTexts: [] });
+  },
+  
+  setRenderManager: (manager: any) => {
+    set({ renderManager: manager });
   }
 }));


### PR DESCRIPTION
Fix game restart not loading the first map's background image.

When restarting the game, `gameState.resetGame()` was called to reset game data and load the first level, but it didn't trigger the background image loading. This was because `GameStateManager` lacked access to the `RenderManager` to call `loadMapBackground`. The fix stores the `RenderManager` in `renderStore` and calls `loadMapBackground` during the `resetGame` process.

---
<a href="https://cursor.com/background-agent?bcId=bc-01530f75-0b37-443b-ba16-5cc48e82def9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01530f75-0b37-443b-ba16-5cc48e82def9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

