### PR TITLE
Reset player velocity on respawn

### DIFF
--- a/src/managers/PlayerManager.ts
+++ b/src/managers/PlayerManager.ts
@@ -282,8 +282,9 @@ export class PlayerManager {
 
   // Reset player position and state
   resetPlayer(x: number, y: number): void {
-    const { player, updatePlayer } = usePlayerStore.getState();
-    updatePlayer({ ...player, x, y });
+    const { setPlayerPosition } = usePlayerStore.getState();
+    // Use setPlayerPosition to properly reset all movement properties
+    setPlayerPosition(x, y);
 
     // Reset animation controller state
     this.animationController.reset();


### PR DESCRIPTION
Use `setPlayerPosition` in `PlayerManager.resetPlayer` to properly reset player velocity and movement states on respawn.

Previously, `PlayerManager.resetPlayer` only updated the player's position (x, y) but did not reset velocity or other movement-related flags. This caused players to inherit their velocity from before death upon respawning. By using `setPlayerPosition`, all relevant movement properties, including `velocityX`, `velocityY`, and various movement flags, are correctly reset to their default values.

---
<a href="https://cursor.com/background-agent?bcId=bc-240443c5-7a2d-4a04-9552-92520082f9b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-240443c5-7a2d-4a04-9552-92520082f9b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

