### PR TITLE
Fix game map state handling

### DIFF
--- a/src/managers/GameStateManager.ts
+++ b/src/managers/GameStateManager.ts
@@ -144,7 +144,9 @@ export class GameStateManager {
     this.handleStateTransition(state);
 
     // Send state update to external system after handling the transition
-    sendGameStateUpdate(state, menuType);
+    // Get the actual current map name from levelStore, not menuType
+    const levelStore = useLevelStore.getState();
+    sendGameStateUpdate(state, levelStore.currentMap?.name);
   }
 
   private handleStateTransition(state: GameState): void {


### PR DESCRIPTION
Corrects game state updates to send the actual map name instead of `menuType` or `undefined`.

Previously, the `sendGameStateUpdate` function was incorrectly passed `menuType` (e.g., 'COUNTDOWN') or `undefined` as the map parameter, leading to misleading logs where the map name was either the state itself or missing. This change ensures the correct map name from `levelStore` is always used.

---
<a href="https://cursor.com/background-agent?bcId=bc-745b8c35-3578-4051-ab51-277c67cf8f35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-745b8c35-3578-4051-ab51-277c67cf8f35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

