### PR TITLE
Fix inconsistent monster spawn timing

### DIFF
--- a/src/managers/GameStateManager.ts
+++ b/src/managers/GameStateManager.ts
@@ -235,9 +235,18 @@ export class GameStateManager {
         // Resume all managers when playing
         // IMPORTANT: Resume in correct order to avoid race conditions
 
+        // Check if we're coming from COUNTDOWN state (game just started/respawned)
+        const wasCountdown = this.previousGameState === GameState.COUNTDOWN;
+
         // 1. Resume spawn/respawn managers first
         this.monsterSpawnManager.resume();
         this.monsterRespawnManager.resume();
+
+        // 1b. Reset spawn timing if coming from countdown to ensure consistent spawn times
+        if (wasCountdown) {
+          this.monsterSpawnManager.resetSpawnTiming();
+          log.spawn("Reset spawn timing after countdown");
+        }
 
         // 2. Resume scaling manager (respects power mode state)
         if (!this.scalingManager.isCurrentlyPausedByPowerMode()) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,9 +5,9 @@ export const VERSION = {
   major: 2,
   minor: 5,
   patch: 0,
-  build: 13,
-  timestamp: 1756036878472,
-  hash: '7LPCVQ',
+  build: 14,
+  timestamp: 1756038937099,
+  hash: 'YHUELY',
   full: '2.5.0'
 };
 


### PR DESCRIPTION
Align monster spawn timings with actual gameplay start to ensure consistent delays after countdown.

The previous implementation set `levelStartTime` at different points relative to the countdown, causing monsters to spawn slightly faster on initial game load and slightly later after respawning. This change resets all monster spawn timings when the game transitions from `COUNTDOWN` to `PLAYING` state, guaranteeing consistent delays from when the player gains control.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9f3b0f9-cb81-4635-b99d-699bb9cf01b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d9f3b0f9-cb81-4635-b99d-699bb9cf01b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

