### PR TITLE
Handle incomplete game records with new events

### DIFF
--- a/src/lib/communicationUtils.ts
+++ b/src/lib/communicationUtils.ts
@@ -1,5 +1,22 @@
 import { log } from "./logger";
 
+export interface LevelStartData {
+  level: number;
+  mapName: string;
+  timestamp: number;
+}
+
+export interface LevelFailureData {
+  level: number;
+  mapName: string;
+  score: number;
+  bombs?: number;
+  correctOrders?: number;
+  lives: number;
+  multiplier: number;
+  timestamp?: number;
+}
+
 export interface MapCompletionData {
   mapName: string;
   level: number;
@@ -29,6 +46,7 @@ export interface LevelHistoryEntry {
   totalBombs: number;
   lives: number;
   multiplier: number;
+  isPartial?: boolean; // True for failed/incomplete levels
 }
 
 export interface GameCompletionData {
@@ -86,6 +104,39 @@ export const sendScoreToHost = (
     composed: true,
   });
   window.dispatchEvent(detailedScoreEvent);
+};
+
+export const sendLevelStart = (level: number, mapName: string) => {
+  const levelStartData: LevelStartData = {
+    level,
+    mapName,
+    timestamp: Date.now(),
+  };
+
+  log.data("Sending level start to host:", levelStartData);
+
+  const event = new CustomEvent("game:level-started", {
+    detail: levelStartData,
+    bubbles: true,
+    composed: true,
+  });
+  window.dispatchEvent(event);
+};
+
+export const sendLevelFailure = (data: LevelFailureData) => {
+  const failureData = {
+    ...data,
+    timestamp: data.timestamp || Date.now(),
+  };
+
+  log.data("Sending level failure to host:", failureData);
+
+  const event = new CustomEvent("game:level-failed", {
+    detail: failureData,
+    bubbles: true,
+    composed: true,
+  });
+  window.dispatchEvent(event);
 };
 
 export const sendGameReady = () => {


### PR DESCRIPTION
Add `game:level-started` and `game:level-failed` events to `communicationUtils.ts` to track partial game completions.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ed8fa25-a182-410e-92d0-2f0670060d09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ed8fa25-a182-410e-92d0-2f0670060d09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

