### PR TITLE
Send latest level data on game over

### DIFF
--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -375,28 +375,28 @@ export class GameManager {
         timestamp: Date.now(),
       };
       sendLevelFailure(failureData);
-
-      // Add partial level result to history
-      const partialLevelResult: LevelHistoryEntry = {
-        level: currentLevel,
-        mapName: currentMap.name,
-        score: score,
-        bonus: 0,
-        completionTime: completionTime,
-        coinsCollected: coinStats.totalCoinsCollected,
-        powerModeActivations: coinStats.totalPowerCoinsCollected,
-        timestamp: Date.now(),
-        correctOrderCount: correctOrderCount,
-        totalBombs: bombs.length,
-        lives: lives - 1,
-        multiplier: multiplier,
-        isPartial: true, // Mark as partial/incomplete
-      };
-      addLevelResult(partialLevelResult as LevelResult);
     }
 
     if (lives <= 1) {
-      // Game over
+      // Game over - only record level data on final death
+      if (currentMap) {
+        const partialLevelResult: LevelHistoryEntry = {
+          level: currentLevel,
+          mapName: currentMap.name,
+          score: score,
+          bonus: 0,
+          completionTime: completionTime,
+          coinsCollected: coinStats.totalCoinsCollected,
+          powerModeActivations: coinStats.totalPowerCoinsCollected,
+          timestamp: Date.now(),
+          correctOrderCount: correctOrderCount,
+          totalBombs: bombs.length,
+          lives: lives - 1,
+          multiplier: multiplier,
+          isPartial: true, // Mark as partial/incomplete
+        };
+        addLevelResult(partialLevelResult as LevelResult);
+      }
       loseLife();
     } else {
       // Respawn player


### PR DESCRIPTION
Record level data only on game over (when lives reach 0) to prevent duplicate entries.

Previously, partial level results were recorded on every player death, leading to multiple `isPartial: true` entries for the same level in the history. This change ensures level data is only recorded once, at the final game over state, providing accurate and non-redundant level history.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b3171ea-cabe-49f6-8d58-877bc9ce9aa0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2b3171ea-cabe-49f6-8d58-877bc9ce9aa0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

