### PR TITLE
Fix game progress reporting on level failure

### DIFF
--- a/src/lib/communicationUtils.ts
+++ b/src/lib/communicationUtils.ts
@@ -38,7 +38,7 @@ export interface LevelHistoryEntry {
   mapName: string;
   score: number;
   bonus: number;
-  completionTime: number;
+  completionTime?: number; // Optional - not included for partial/incomplete levels
   coinsCollected: number;
   powerModeActivations: number;
   timestamp: number;

--- a/src/managers/GameManager.ts
+++ b/src/managers/GameManager.ts
@@ -347,11 +347,11 @@ export class GameManager {
         }
       : { score: 0, multiplier: 1 };
     const { currentMap, addLevelResult } = useLevelStore.getState();
-    const { getCoinStats } = useCoinStore.getState();
+    const { getLevelCoinStats } = useCoinStore.getState();
     const { bombs } = useStateStore.getState();
 
-    // Get coin stats before reset
-    const coinStats = getCoinStats();
+    // Get level coin stats (accumulated across respawns)
+    const coinStats = getLevelCoinStats();
     const levelStartTime = useLevelStore.getState().levelStartTime;
     const completionTime = Date.now() - levelStartTime;
 
@@ -385,7 +385,7 @@ export class GameManager {
           mapName: currentMap.name,
           score: score,
           bonus: 0,
-          completionTime: completionTime,
+          // Don't include completionTime for partial levels - the level wasn't completed
           coinsCollected: coinStats.totalCoinsCollected,
           powerModeActivations: coinStats.totalPowerCoinsCollected,
           timestamp: Date.now(),

--- a/src/managers/LevelManager.ts
+++ b/src/managers/LevelManager.ts
@@ -165,7 +165,7 @@ export class LevelManager {
       setBonusAnimationComplete,
       gameStateManager,
     } = useStateStore.getState();
-    const { getCoinStats, resetEffects, resetCoinState, coinManager } =
+    const { getLevelCoinStats, resetEffects, resetCoinState, resetLevelCoinCounters, coinManager } =
       useCoinStore.getState();
     const { currentMap, addLevelResult } = useLevelStore.getState();
     const { score, multiplier, addScore, addRawScore } = useScoreStore.getState();
@@ -186,8 +186,8 @@ export class LevelManager {
     // Calculate completion time
     const completionTime = Date.now() - this.mapStartTime;
 
-    // Capture coin stats BEFORE resetting
-    const coinStats = getCoinStats();
+    // Capture level coin stats BEFORE resetting
+    const coinStats = getLevelCoinStats();
     const coinsCollected = coinStats.totalCoinsCollected;
     const powerModeActivations = coinStats.totalPowerCoinsCollected;
 
@@ -244,7 +244,7 @@ export class LevelManager {
 
   public proceedToNextLevel(): void {
     const { nextLevel, currentLevel, gameStateManager } = useStateStore.getState();
-    const { resetEffects, resetCoinState } = useCoinStore.getState();
+    const { resetEffects, resetCoinState, resetLevelCoinCounters } = useCoinStore.getState();
 
     // Stop power-up melody if active
     gameStateManager.stopPowerUpMelodyIfActive();
@@ -255,6 +255,7 @@ export class LevelManager {
       // Reset coin effects and state
       resetEffects();
       resetCoinState();
+      resetLevelCoinCounters(); // Reset level-specific counters for the new level
       log.debug("Coins reset when proceeding to next level");
 
       // Increment level only once

--- a/src/stores/entities/coinStore.ts
+++ b/src/stores/entities/coinStore.ts
@@ -18,6 +18,11 @@ interface CoinState {
   totalPowerCoinsCollected: number;
   totalBonusMultiplierCoinsCollected: number;
   totalExtraLifeCoinsCollected: number;
+  // Level-specific counters that accumulate across respawns
+  levelCoinsCollected: number;
+  levelPowerCoinsCollected: number;
+  levelBonusMultiplierCoinsCollected: number;
+  levelExtraLifeCoinsCollected: number;
 }
 
 interface CoinActions {
@@ -26,9 +31,16 @@ interface CoinActions {
   collectCoin: (coin: Coin) => void;
   onFirebombCollected: () => void;
   resetCoinState: () => void;
+  resetLevelCoinCounters: () => void;
   updateMonsterStates: (monsters: Monster[]) => void;
   resetEffects: () => void;
   getCoinStats: () => {
+    totalCoinsCollected: number;
+    totalPowerCoinsCollected: number;
+    totalBonusMultiplierCoinsCollected: number;
+    totalExtraLifeCoinsCollected: number;
+  };
+  getLevelCoinStats: () => {
     totalCoinsCollected: number;
     totalPowerCoinsCollected: number;
     totalBonusMultiplierCoinsCollected: number;
@@ -51,6 +63,11 @@ export const useCoinStore = create<CoinStore>((set, get) => ({
   totalPowerCoinsCollected: 0,
   totalBonusMultiplierCoinsCollected: 0,
   totalExtraLifeCoinsCollected: 0,
+  // Level-specific counters
+  levelCoinsCollected: 0,
+  levelPowerCoinsCollected: 0,
+  levelBonusMultiplierCoinsCollected: 0,
+  levelExtraLifeCoinsCollected: 0,
 
   // Actions
   setCoins: (coins: Coin[]) => {
@@ -109,6 +126,17 @@ export const useCoinStore = create<CoinStore>((set, get) => ({
       currentState.totalExtraLifeCoinsCollected +
       (coin.type === "EXTRA_LIFE" ? 1 : 0);
 
+    // Update level-specific counters (these accumulate across respawns)
+    const newLevelCoinsCollected = currentState.levelCoinsCollected + 1;
+    const newLevelPowerCoinsCollected =
+      currentState.levelPowerCoinsCollected + (coin.type === "POWER" ? 1 : 0);
+    const newLevelBonusMultiplierCoinsCollected =
+      currentState.levelBonusMultiplierCoinsCollected +
+      (coin.type === "BONUS_MULTIPLIER" ? 1 : 0);
+    const newLevelExtraLifeCoinsCollected =
+      currentState.levelExtraLifeCoinsCollected +
+      (coin.type === "EXTRA_LIFE" ? 1 : 0);
+
     set({
       coins: updatedCoins,
       activeEffects,
@@ -116,6 +144,10 @@ export const useCoinStore = create<CoinStore>((set, get) => ({
       totalPowerCoinsCollected: newTotalPowerCoinsCollected,
       totalBonusMultiplierCoinsCollected: newTotalBonusMultiplierCoinsCollected,
       totalExtraLifeCoinsCollected: newTotalExtraLifeCoinsCollected,
+      levelCoinsCollected: newLevelCoinsCollected,
+      levelPowerCoinsCollected: newLevelPowerCoinsCollected,
+      levelBonusMultiplierCoinsCollected: newLevelBonusMultiplierCoinsCollected,
+      levelExtraLifeCoinsCollected: newLevelExtraLifeCoinsCollected,
     });
 
     // Handle coin-specific effects by calling the individual stores
@@ -177,6 +209,7 @@ export const useCoinStore = create<CoinStore>((set, get) => ({
       coinManager.reset();
     }
 
+    // Don't reset level-specific counters here - they accumulate across respawns
     set({
       coins: [],
       activeEffects: {
@@ -191,6 +224,16 @@ export const useCoinStore = create<CoinStore>((set, get) => ({
     });
   },
 
+  resetLevelCoinCounters: () => {
+    // Reset level-specific counters when moving to a new level
+    set({
+      levelCoinsCollected: 0,
+      levelPowerCoinsCollected: 0,
+      levelBonusMultiplierCoinsCollected: 0,
+      levelExtraLifeCoinsCollected: 0,
+    });
+  },
+
   getCoinStats: () => {
     const state = get();
     return {
@@ -199,6 +242,17 @@ export const useCoinStore = create<CoinStore>((set, get) => ({
       totalBonusMultiplierCoinsCollected:
         state.totalBonusMultiplierCoinsCollected,
       totalExtraLifeCoinsCollected: state.totalExtraLifeCoinsCollected,
+    };
+  },
+
+  getLevelCoinStats: () => {
+    const state = get();
+    return {
+      totalCoinsCollected: state.levelCoinsCollected,
+      totalPowerCoinsCollected: state.levelPowerCoinsCollected,
+      totalBonusMultiplierCoinsCollected:
+        state.levelBonusMultiplierCoinsCollected,
+      totalExtraLifeCoinsCollected: state.levelExtraLifeCoinsCollected,
     };
   },
 

--- a/src/stores/game/levelStore.ts
+++ b/src/stores/game/levelStore.ts
@@ -14,7 +14,7 @@ export interface LevelResult {
   hasBonus: boolean;
   coinsCollected: number;
   powerModeActivations: number;
-  completionTime: number;
+  completionTime?: number; // Optional - not included for partial/incomplete levels
   timestamp: number;
   lives: number;
   multiplier: number;

--- a/src/stores/game/stateStore.ts
+++ b/src/stores/game/stateStore.ts
@@ -174,7 +174,7 @@ export const useStateStore = create<StateStore>((set, get) => ({
       const gameCompletionData: GameCompletionData = {
         finalScore: score,
         totalLevels: mapDefinitions.length,
-        completedLevels: levelResults.length,
+        completedLevels: levelResults.filter((l: any) => !l.isPartial).length,
         timestamp: Date.now(),
         lives: newLives,
         multiplier,

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -60,6 +60,7 @@ export const useGameStore = create<GameStore>((set, get, api) => ({
     levelStore.resetLevelHistory();
     coinStore.resetCoinState();
     coinStore.resetEffects();
+    coinStore.resetLevelCoinCounters();
     monsterStore.resetMonsters();
     audioStore.resetAudioSettings();
     inputStore.resetInput();

--- a/src/stores/slices/gameStateSlice.ts
+++ b/src/stores/slices/gameStateSlice.ts
@@ -169,7 +169,7 @@ export const createGameStateSlice: StateCreator<GameStateSlice> = (
         const gameCompletionData: GameCompletionData = {
           finalScore: get().score,
           totalLevels: mapDefinitions.length,
-          completedLevels: levelResults.length,
+          completedLevels: levelResults.filter((l: any) => !l.isPartial).length,
           timestamp: Date.now(),
           lives: newLives,
           multiplier,

--- a/src/stores/slices/levelHistorySlice.ts
+++ b/src/stores/slices/levelHistorySlice.ts
@@ -10,7 +10,7 @@ export interface LevelResult {
   hasBonus: boolean;
   coinsCollected: number;
   powerModeActivations: number;
-  completionTime: number;
+  completionTime?: number; // Optional - not included for partial/incomplete levels
   timestamp: number;
   lives: number;
   multiplier: number;

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,9 +5,9 @@ export const VERSION = {
   major: 2,
   minor: 6,
   patch: 0,
-  build: 0,
-  timestamp: 1756049070565,
-  hash: 'VX9U92',
+  build: 1,
+  timestamp: 1756062511288,
+  hash: 'ZAWEFY',
   full: '2.6.0'
 };
 


### PR DESCRIPTION
Correct game completion data reporting by accurately counting completed levels, omitting completion times for partial levels, and cumulatively tracking coins across respawns.

The previous implementation incorrectly counted all level attempts as 'completed', included completion times for levels where the player died, and reset coin counts upon respawn, leading to inaccurate statistics in the final game completion and level history data. This PR addresses these discrepancies to provide precise game analytics.

---
<a href="https://cursor.com/background-agent?bcId=bc-902be6cc-73a0-4a22-8b62-b4a154245ff9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-902be6cc-73a0-4a22-8b62-b4a154245ff9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

