### PR TITLE
Ensure completed levels have isPartial false

### DIFF
--- a/src/managers/LevelManager.ts
+++ b/src/managers/LevelManager.ts
@@ -216,6 +216,7 @@ export class LevelManager {
         timestamp: Date.now(),
         lives: lives,
         multiplier: multiplier,
+        isPartial: false, // Explicitly mark as completed level
       };
       addLevelResult(levelResult);
 

--- a/src/stores/game/levelStore.ts
+++ b/src/stores/game/levelStore.ts
@@ -128,7 +128,8 @@ export const useLevelStore = create<LevelStore>((set, get) => ({
         lives: result.lives || 0,
         multiplier: result.multiplier || 1,
         totalBombs: result.totalBombs || 0,
-        correctOrderCount: result.correctOrderCount || 0
+        correctOrderCount: result.correctOrderCount || 0,
+        isPartial: result.isPartial || false  // Default to false (completed) if not specified
       }]
     }));
   },


### PR DESCRIPTION
Add `isPartial: false` to completed level results to ensure data consistency.

Previously, completed levels did not explicitly include the `isPartial` property, leading to inconsistencies when processing game completion data and calculating `completedLevels`. This change ensures all levels in `levelHistory` consistently have the `isPartial` property, defaulting to `false` for completed levels.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2ba32b9-4bb6-4dfb-bb37-a2c6ecf23d5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2ba32b9-4bb6-4dfb-bb37-a2c6ecf23d5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

