### PR TITLE
Replace background music file

### DIFF
--- a/src/config/assets.ts
+++ b/src/config/assets.ts
@@ -10,7 +10,7 @@ const backgrounds = import.meta.glob(
 ) as Record<string, { default: string }>;
 
 const audioFiles = import.meta.glob(
-  '../assets/audio/*.wav',
+  '../assets/audio/*.{wav,mp3}',
   { eager: true }
 ) as Record<string, { default: string }>;
 
@@ -60,7 +60,12 @@ export const getAudioPath = (name: string): string => {
   // Find by filename with or without extension
   const match = Object.entries(audioFiles).find(([path]) => {
     const filename = path.split('/').pop() || '';
-    return filename === name || filename === `${name}.wav` || filename.startsWith(name);
+    const nameWithoutExt = filename.replace(/\.(wav|mp3)$/, '');
+    return filename === name || 
+           filename === `${name}.wav` || 
+           filename === `${name}.mp3` || 
+           nameWithoutExt === name ||
+           filename.startsWith(name);
   });
 
   // console.log(`🔍 Audio match found:`, match);


### PR DESCRIPTION
Add support for MP3 background music files to allow more flexible and efficient audio asset usage.

The previous configuration only imported and recognized `.wav` files. This change updates the asset import glob and the `getAudioPath` utility to correctly identify and load both `.wav` and `.mp3` files, enabling users to easily switch to more compressed audio formats.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f9a224d-418a-47cc-ab88-2454f5cd141e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5f9a224d-418a-47cc-ab88-2454f5cd141e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

