### PR TITLE
Persist sound settings to user profile

### DIFF
--- a/src/components/menu/menus/SettingsMenu.tsx
+++ b/src/components/menu/menus/SettingsMenu.tsx
@@ -5,6 +5,7 @@ import {
   useGameStore,
   useStateStore,
 } from "../../../stores/gameStore";
+import { sendAudioSettingsUpdate } from "../../../lib/communicationUtils";
 
 import { ArrowLeft } from "lucide-react";
 
@@ -29,8 +30,30 @@ const SettingsMenu: React.FC = () => {
   };
 
   const goBack = () => {
+    // Send audio settings to host before closing
+    sendAudioSettingsUpdate(
+      masterVolume,
+      musicVolume,
+      sfxVolume,
+      masterMuted,
+      musicMuted,
+      sfxMuted
+    );
+    
     // Use centralized close settings transition
     gameStateManager?.closeNestedMenu();
+  };
+
+  const handleUpdateAudio = () => {
+    // Send audio settings to host for storage
+    sendAudioSettingsUpdate(
+      masterVolume,
+      musicVolume,
+      sfxVolume,
+      masterMuted,
+      musicMuted,
+      sfxMuted
+    );
   };
 
   return (
@@ -132,7 +155,9 @@ const SettingsMenu: React.FC = () => {
             disabled={sfxMuted}
           />
         </div>
-        <Button variant="default">Oppdater lyd</Button>
+        <Button variant="default" onClick={handleUpdateAudio}>
+          Oppdater lyd
+        </Button>
         <div className="text-center text-sm text-gray-400">
           <p>(Trykk på tallene for å mute lyd)</p>
         </div>

--- a/src/lib/communicationUtils.ts
+++ b/src/lib/communicationUtils.ts
@@ -71,6 +71,16 @@ export interface GameCompletionData {
   userId?: string;
 }
 
+export interface AudioSettingsUpdateData {
+  masterVolume: number;
+  musicVolume: number;
+  sfxVolume: number;
+  masterMuted: boolean;
+  musicMuted: boolean;
+  sfxMuted: boolean;
+  timestamp: number;
+}
+
 export const sendScoreToHost = (
   score: number,
   map: string,
@@ -165,6 +175,34 @@ export const sendGameCompletionData = (data: GameCompletionData) => {
   log.data("Sending game completion data to host:", data);
   const event = new CustomEvent("game:completed", {
     detail: data,
+    bubbles: true,
+    composed: true,
+  });
+  window.dispatchEvent(event);
+};
+
+export const sendAudioSettingsUpdate = (
+  masterVolume: number,
+  musicVolume: number,
+  sfxVolume: number,
+  masterMuted: boolean,
+  musicMuted: boolean,
+  sfxMuted: boolean
+) => {
+  const audioSettingsData: AudioSettingsUpdateData = {
+    masterVolume,
+    musicVolume,
+    sfxVolume,
+    masterMuted,
+    musicMuted,
+    sfxMuted,
+    timestamp: Date.now(),
+  };
+
+  log.data("Sending audio settings update to host:", audioSettingsData);
+
+  const event = new CustomEvent("game:audio-settings-updated", {
+    detail: audioSettingsData,
     bubbles: true,
     composed: true,
   });


### PR DESCRIPTION
Implement an event system to send audio settings to the host for user profile storage, ensuring persistence across sessions.

---
<a href="https://cursor.com/background-agent?bcId=bc-575b4b67-ac8c-406c-aa94-8af40027b742">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-575b4b67-ac8c-406c-aa94-8af40027b742">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

