### PR TITLE
Persist and restore game audio settings

### DIFF
--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -50,7 +50,7 @@ export const useGameStore = create<GameStore>((set, get, api) => ({
     const inputStore = useInputStore.getState();
     const renderStore = useRenderStore.getState();
 
-    // Reset all state
+    // Reset all game state (but preserve audio settings as they are user preferences)
     stateStore.resetGameState();
     stateStore.resetBombState();
     scoreStore.resetScore();
@@ -62,7 +62,7 @@ export const useGameStore = create<GameStore>((set, get, api) => ({
     coinStore.resetEffects();
     coinStore.resetLevelCoinCounters();
     monsterStore.resetMonsters();
-    audioStore.resetAudioSettings();
+    // audioStore.resetAudioSettings(); // Don't reset audio settings - they should persist
     inputStore.resetInput();
     renderStore.clearAllFloatingTexts();
     


### PR DESCRIPTION
Prevent audio settings from resetting on game restart to ensure user preferences persist across sessions.

Previously, the `resetGame()` function in `gameStore.ts` incorrectly reset audio settings along with other game state, causing them to revert to defaults after a game over. This change ensures audio settings, as user preferences, are preserved.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1c0b55f-2afb-4d51-88c9-6cd3f4c2aa13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1c0b55f-2afb-4d51-88c9-6cd3f4c2aa13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

