### PR TITLE
Adapt victory menu layout from game over screen

### DIFF
--- a/src/components/menu/menus/VictoryMenu.tsx
+++ b/src/components/menu/menus/VictoryMenu.tsx
@@ -1,14 +1,19 @@
 import React, { useState, useEffect } from "react";
-
-import { useScoreStore, useStateStore } from "../../../stores/gameStore";
+import { Button } from "@/components/ui/button";
+import { 
+  useLevelStore, 
+  useStateStore 
+} from "../../../stores/gameStore";
 import { waitForGameSaveConfirmation } from "../../../lib/communicationUtils";
-
-import { Home, Loader2 } from "lucide-react";
+import { Loader2, Check } from "lucide-react";
 
 const VictoryMenu: React.FC = () => {
   const { gameStateManager } = useStateStore.getState();
-  const { score } = useScoreStore.getState();
+  const { getLevelResults } = useLevelStore.getState();
   const [isSaving, setIsSaving] = useState(true);
+
+  // Get the comprehensive level results
+  const levelResults = getLevelResults();
 
   useEffect(() => {
     // Wait for the game to be saved before allowing restart
@@ -23,43 +28,103 @@ const VictoryMenu: React.FC = () => {
     }
   };
 
+  // Calculate total financing across all levels
+  const totalFinancing = levelResults.reduce(
+    (sum, level) => sum + level.score,
+    0
+  );
+
   return (
-    <div className="text-center max-w-md flex flex-col items-center justify-center gap-4">
-      <h1 className="text-2xl font-bold uppercase">slutt</h1>
+    <div className="text-center max-w-2xl">
+      <h1 className="text-4xl font-bold text-white mb-2 font-pixel">
+        Unicorn Founder
+      </h1>
 
-      <div className="text-white mb-6 space-y-4">
-        <div className="text-2xl text-primary">Du har klart det umulige!</div>
-        <div className="text-lg">
-          Du hjalp Sigurd med å unngå byrokratiske hindringer og samle
-          finansiering.
+      <div className="text-white mb-6 space-y-3">
+        <div className="text-lg text-primary">
+          Du har bygget en billion-dollar idé
         </div>
 
-        <div className="text-2xl flex flex-col items-center justify-center gap-2">
-          <div className="text-foreground">Total finansiering samlet:</div>
-          <div className="font-bold text-3xl text-primary">
-            {score.toLocaleString()}
+        {/* Level Results Table */}
+        {levelResults.length > 0 && (
+          <div className="mt-4">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-600">
+                    <th className="text-left py-2 px-3 text-primary font-semibold">
+                      Bane
+                    </th>
+                    <th className="text-right py-2 px-3 text-primary font-semibold">
+                      Finansiering
+                    </th>
+                    <th className="text-right py-2 px-3 text-primary font-semibold">
+                      Bonus
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {levelResults.map((level, index) => (
+                    <tr key={index} className="border-b border-gray-700/50">
+                      <td className="py-2 px-3 text-left text-gray-300">
+                        <Check className="w-4 h-4 text-primary inline mr-2" />
+                        <span className="font-medium">{level.mapName}</span>
+                        <span className="text-xs text-gray-500 ml-2">
+                          (Nivå {level.level})
+                        </span>
+                      </td>
+                      <td className="py-2 px-3 text-right text-gray-300">
+                        {level.score.toLocaleString()} kr
+                      </td>
+                      <td className="py-2 px-3 text-right">
+                        {level.bonus > 0 ? (
+                          <span className="text-yellow-400 font-semibold">
+                            {level.bonus.toLocaleString()} kr
+                          </span>
+                        ) : (
+                          <span className="text-gray-500">-</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+                <tfoot>
+                  <tr className="border-t-2 border-primary">
+                    <td className="py-3 px-3 text-left font-bold text-primary">
+                      Total finansiering
+                    </td>
+                    <td
+                      colSpan={2}
+                      className="py-3 px-3 text-right font-bold text-primary text-xl"
+                    >
+                      {totalFinancing.toLocaleString()} kr
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
-      <div className="flex flex-col items-center justify-center gap-2">
+      <div className="flex flex-col items-center gap-3 mt-6">
         {isSaving && (
           <div className="text-sm text-gray-400 flex items-center gap-2">
             <Loader2 className="w-4 h-4 animate-spin" />
             Lagrer spillet...
           </div>
         )}
-        <button
+        <Button
           onClick={handleRestart}
           disabled={isSaving}
           className={`${
-            isSaving 
-              ? "bg-gray-500 cursor-not-allowed" 
+            isSaving
+              ? "bg-gray-500 hover:bg-gray-500 cursor-not-allowed"
               : "bg-primary hover:bg-primary-dark"
-          } text-white font-bold rounded-lg py-1 px-3 text-lg transition-all duration-200 flex items-center justify-center gap-2`}
+          } text-white font-bold py-3 px-8 text-lg transition-all duration-200 uppercase`}
         >
-          <Home className="w-7 h-7" strokeWidth={2} />
-        </button>
+          prøv igjen
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
Refactor `VictoryMenu` to match `GameOverScreen` layout, displaying detailed level results with a new title and subtitle.

---
<a href="https://cursor.com/background-agent?bcId=bc-aba111b7-6821-46c1-a8f3-ba964a4a0eb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aba111b7-6821-46c1-a8f3-ba964a4a0eb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

