### PR TITLE
Fix financing score calculation

### DIFF
--- a/src/components/menu/menus/GameOverScreen.tsx
+++ b/src/components/menu/menus/GameOverScreen.tsx
@@ -29,9 +29,14 @@ const GameOverScreen: React.FC = () => {
     }
   };
 
-  // Calculate total financing across all levels
+  // Calculate total financing and bonus separately
   const totalFinancing = levelResults.reduce(
     (sum, level) => sum + level.score,
+    0
+  );
+  
+  const totalBonus = levelResults.reduce(
+    (sum, level) => sum + level.bonus,
     0
   );
 
@@ -106,17 +111,22 @@ const GameOverScreen: React.FC = () => {
                 </tbody>
                 <tfoot>
                   <tr className="border-t-2 border-primary">
-                    <td
-                      colSpan={2}
-                      className="py-3 px-3 text-left font-bold text-primary"
-                    >
-                      Total finansiering
+                    <td colSpan={2} className="py-3 px-3 text-left font-bold text-primary">
+                      Total
                     </td>
-                    <td
-                      colSpan={2}
-                      className="py-3 px-3 text-right font-bold text-primary text-xl"
-                    >
+                    <td className="py-3 px-3 text-right font-bold text-primary text-xl">
                       {totalFinancing.toLocaleString()} kr
+                    </td>
+                    <td className="py-3 px-3 text-right font-bold text-yellow-400 text-xl">
+                      {totalBonus > 0 ? `${totalBonus.toLocaleString()} kr` : '-'}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td colSpan={2} className="py-2 px-3 text-left font-bold text-white">
+                      Sum total
+                    </td>
+                    <td colSpan={2} className="py-2 px-3 text-right font-bold text-white text-2xl">
+                      {(totalFinancing + totalBonus).toLocaleString()} kr
                     </td>
                   </tr>
                 </tfoot>

--- a/src/components/menu/menus/VictoryMenu.tsx
+++ b/src/components/menu/menus/VictoryMenu.tsx
@@ -28,9 +28,14 @@ const VictoryMenu: React.FC = () => {
     }
   };
 
-  // Calculate total financing across all levels
+  // Calculate total financing and bonus separately
   const totalFinancing = levelResults.reduce(
     (sum, level) => sum + level.score,
+    0
+  );
+  
+  const totalBonus = levelResults.reduce(
+    (sum, level) => sum + level.bonus,
     0
   );
 
@@ -91,13 +96,21 @@ const VictoryMenu: React.FC = () => {
                 <tfoot>
                   <tr className="border-t-2 border-primary">
                     <td className="py-3 px-3 text-left font-bold text-primary">
-                      Total finansiering
+                      Total
                     </td>
-                    <td
-                      colSpan={2}
-                      className="py-3 px-3 text-right font-bold text-primary text-xl"
-                    >
+                    <td className="py-3 px-3 text-right font-bold text-primary text-xl">
                       {totalFinancing.toLocaleString()} kr
+                    </td>
+                    <td className="py-3 px-3 text-right font-bold text-yellow-400 text-xl">
+                      {totalBonus > 0 ? `${totalBonus.toLocaleString()} kr` : '-'}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 px-3 text-left font-bold text-white">
+                      Sum total
+                    </td>
+                    <td colSpan={2} className="py-2 px-3 text-right font-bold text-white text-2xl">
+                      {(totalFinancing + totalBonus).toLocaleString()} kr
                     </td>
                   </tr>
                 </tfoot>

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,9 +5,9 @@ export const VERSION = {
   major: 2,
   minor: 8,
   patch: 0,
-  build: 1,
-  timestamp: 1756306546959,
-  hash: 'DUS920',
+  build: 2,
+  timestamp: 1756309302289,
+  hash: 'BSOZP7',
   full: '2.8.0'
 };
 


### PR DESCRIPTION
Separate financing and bonus calculations and display in end-game menus to correctly reflect in-game earnings and bonuses.

The previous implementation incorrectly combined in-game earnings and bonus points under a single "Total finansiering" column, leading to a misleading final score. This PR ensures that financing (in-game earned) and bonus are calculated and displayed distinctly, with a clear grand total.

---
<a href="https://cursor.com/background-agent?bcId=bc-efe51c06-aadf-4b15-bbd8-7c69f4b43740">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-efe51c06-aadf-4b15-bbd8-7c69f4b43740">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

