### PR TITLE
Debug monster speed and m-coin spawning

### DIFF
--- a/src/managers/LevelManager.ts
+++ b/src/managers/LevelManager.ts
@@ -77,6 +77,10 @@ export class LevelManager {
       // Cleanup spawn manager before loading new level
       this.monsterSpawnManager.cleanup();
 
+      // IMPORTANT: Start difficulty scaling for this map BEFORE initializing monsters
+      // This ensures monsters get the correct spawn time and start at base speed
+      this.scalingManager.startMap();
+
       // Use the gameStore initializeLevel which properly sets up bombs, monsters, coins, and player
       gameStore.initializeLevel(mapDefinition);
 
@@ -85,9 +89,6 @@ export class LevelManager {
 
       // Reset animation controller state
       this.animationController.reset();
-
-      // Start difficulty scaling for this map
-      this.scalingManager.startMap();
 
       // Load parallax background (non-blocking)
       this.renderManager.loadMapBackground(mapDefinition.name);

--- a/src/managers/coinManager.ts
+++ b/src/managers/coinManager.ts
@@ -60,6 +60,22 @@ export class CoinManager {
     // Don't reset pCoinColorIndex - let it persist across sessions
   }
 
+  // Update spawn points when loading a new level
+  updateSpawnPoints(spawnPoints: CoinSpawnPoint[]): void {
+    this.spawnPoints = spawnPoints;
+    log.debug(`Updated coin spawn points for new level: ${spawnPoints.length} spawn points`);
+  }
+
+  // Clear active coins but preserve score tracking for new level
+  clearActiveCoins(): void {
+    this.coins = [];
+    this.powerModeActive = false;
+    this.powerModeEndTime = 0;
+    this.activeEffects.clear();
+    // Don't clear score tracking or firebomb count - these persist across levels
+    log.debug(`Cleared active coins for new level, preserved score tracking (bombAndMonsterPoints: ${this.bombAndMonsterPoints})`);
+  }
+
   update(
     platforms: Platform[],
     ground: Ground,

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -104,9 +104,19 @@ export const useGameStore = create<GameStore>((set, get, api) => ({
     stateStore.setBombs(bombsWithState);
     stateStore.setBombManager(bombManager);
 
-    // Initialize coin manager
-    const coinManager = new CoinManager(mapData.coinSpawnPoints || []);
-    coinStore.setCoinManager(coinManager);
+    // Initialize or update coin manager
+    // Check if we already have a coin manager (preserve score tracking across levels)
+    const existingCoinManager = coinStore.coinManager;
+    if (existingCoinManager) {
+      // Update spawn points for new level but preserve score tracking
+      existingCoinManager.updateSpawnPoints(mapData.coinSpawnPoints || []);
+      // Clear active coins but preserve score tracking
+      existingCoinManager.clearActiveCoins();
+    } else {
+      // First time initialization
+      const coinManager = new CoinManager(mapData.coinSpawnPoints || []);
+      coinStore.setCoinManager(coinManager);
+    }
 
     // Initialize monsters
     monsterStore.initializeMonsters(mapData.monsters);

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,9 +5,9 @@ export const VERSION = {
   major: 2,
   minor: 8,
   patch: 0,
-  build: 3,
-  timestamp: 1756309776659,
-  hash: 'IN2G6G',
+  build: 4,
+  timestamp: 1756330267281,
+  hash: 'GZEPL1',
   full: '2.8.0'
 };
 


### PR DESCRIPTION
Fix monster initial speed and M-coin spawning by reordering level initialization and preserving CoinManager state across levels.

Monsters were starting at high speed because the `scalingManager.startMap()` call, which resets difficulty scaling, occurred *after* monsters were initialized. This meant monsters inherited scaled speeds from previous levels instead of starting at base speed. M-coins were not spawning because a new `CoinManager` instance was created for each level, resetting the `bombAndMonsterPoints` counter and losing score tracking across level transitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-6882fcc5-b528-4b15-a5c9-a1011a276555">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6882fcc5-b528-4b15-a5c9-a1011a276555">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

