### PR TITLE
Fix bonus multiplier coin spawning logic

### DIFF
--- a/src/managers/coinManager.ts
+++ b/src/managers/coinManager.ts
@@ -46,7 +46,23 @@ export class CoinManager {
     log.debug("CoinManager initialized");
   }
 
+  // Soft reset - preserve spawn tracking across deaths/levels
   reset(): void {
+    this.coins = [];
+    this.firebombCount = 0;
+    this.powerModeActive = false;
+    this.powerModeEndTime = 0;
+    this.activeEffects.clear();
+    // DON'T clear triggeredSpawnConditions - preserve across deaths/levels
+    // DON'T reset lastProcessedScore - preserve across deaths/levels  
+    // DON'T reset lastScoreCheck - preserve across deaths/levels
+    // DON'T reset bombAndMonsterPoints - preserve across deaths/levels
+    this.monsterKillCount = 0;
+    // Don't reset pCoinColorIndex - let it persist across sessions
+  }
+
+  // Hard reset - complete reset for new game
+  hardReset(): void {
     this.coins = [];
     this.firebombCount = 0;
     this.powerModeActive = false;

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -61,6 +61,7 @@ export const useGameStore = create<GameStore>((set, get, api) => ({
     coinStore.resetCoinState();
     coinStore.resetEffects();
     coinStore.resetLevelCoinCounters();
+    coinStore.resetTotalCoinCounters(); // Reset total counters only on new game
     monsterStore.resetMonsters();
     // audioStore.resetAudioSettings(); // Don't reset audio settings - they should persist
     inputStore.resetInput();


### PR DESCRIPTION
Persist bonus coin collection count across player deaths and level changes to correctly spawn EXTRA_LIFE coins.

---
<a href="https://cursor.com/background-agent?bcId=bc-277675d6-06d1-4c7a-b773-c8d17c202118">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-277675d6-06d1-4c7a-b773-c8d17c202118">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

